### PR TITLE
Password reset feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11840,9 +11840,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
-      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
+      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react-router-dom": "^5.1.3",
     "firebase": "^7.13.1",
     "material-ui-icons": "^1.0.0-beta.36",
-    "query-string": "^6.11.1",
+    "query-string": "^6.12.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -8,6 +8,7 @@ import SettingsView from './shared/features/SettingsView/SettingsView';
 import AddAccountLink from './shared/features/AddAccountLink';
 import PhotoReplyPrototype from './shared/features/PhotoReplyPrototype';
 import ResetPassword from './shared/features/ResetPassword';
+import HandleReset from './shared/features/HandleReset';
 
 import { RouteComponentProps, withRouter, Switch, useHistory } from "react-router";
 import { Route } from "react-router-dom";
@@ -50,6 +51,7 @@ const Routes: React.FC<IRoutes & RouteComponentProps> = (props) => {   // {} is 
           <Route exact path="/register" component={Register} />
           <Route exact path="/login" component={Login} />
           <Route exact path="/resetPassword" component={ResetPassword} />
+          <Route exact path="/handleReset" component={HandleReset} />
           <ProtectedRouteHoc exact path="/registerDetails" isLoggedIn={isLoggedIn} public={false} RouteComponent={RegisterDetails} />
           <ProtectedRouteHoc exact setIsLoading={setIsLoading} path="/posts" isLoggedIn={isLoggedIn} public={false} RouteComponent={PostsView} />
           {/*<ProtectedRouteHoc exact path="/postDetails" isLoggedIn={isLoggedIn} public={false} RouteComponent={PostDetails} />*/} {/* use modals instead */}

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,6 +7,7 @@ import PostsView from './shared/features/PostsView/PostsView';
 import SettingsView from './shared/features/SettingsView/SettingsView';
 import AddAccountLink from './shared/features/AddAccountLink';
 import PhotoReplyPrototype from './shared/features/PhotoReplyPrototype';
+import ResetPassword from './shared/features/ResetPassword';
 
 import { RouteComponentProps, withRouter, Switch, useHistory } from "react-router";
 import { Route } from "react-router-dom";
@@ -48,6 +49,7 @@ const Routes: React.FC<IRoutes & RouteComponentProps> = (props) => {   // {} is 
           <Route exact path="/" component={Login} /> {/* default route */}
           <Route exact path="/register" component={Register} />
           <Route exact path="/login" component={Login} />
+          <Route exact path="/resetPassword" component={ResetPassword} />
           <ProtectedRouteHoc exact path="/registerDetails" isLoggedIn={isLoggedIn} public={false} RouteComponent={RegisterDetails} />
           <ProtectedRouteHoc exact setIsLoading={setIsLoading} path="/posts" isLoggedIn={isLoggedIn} public={false} RouteComponent={PostsView} />
           {/*<ProtectedRouteHoc exact path="/postDetails" isLoggedIn={isLoggedIn} public={false} RouteComponent={PostDetails} />*/} {/* use modals instead */}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -23,11 +23,23 @@ export const updateUserProfile = async (displayName: string, email: string) => {
 
       await user.updateEmail(email);
     }
-
     // todo: password update
     return true;
   } catch(e) {
     console.log(e.message);
+    throw Error(e.message);
+  }
+}
+
+export const sendPasswordResetEmail = async (emailAddress: string) => {
+  const auth = firebase.auth();
+
+  try {
+    console.log("Sending 'reset password' email to: ", emailAddress);
+    await auth.sendPasswordResetEmail(emailAddress);
+    return true;
+  } catch(e) {
+    // no user exists with this email 
     throw Error(e.message);
   }
 }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -35,7 +35,6 @@ export const sendPasswordResetEmail = async (emailAddress: string) => {
   const auth = firebase.auth();
 
   try {
-    console.log("Sending 'reset password' email to: ", emailAddress);
     await auth.sendPasswordResetEmail(emailAddress);
     return true;
   } catch(e) {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -213,3 +213,28 @@ export const authenticateFromStore = async () => {
 
   return isAuthenticated;
 }
+
+export const verifyActionCode = async (actionCode: string) => {
+  const auth = firebase.auth();
+  try {
+    let email = await auth.verifyPasswordResetCode(actionCode);
+    return email;
+  } catch(e) {
+    // invalid or expired action code, ask the user to try to reset the password again 
+    throw Error(e.message);
+  }
+}
+
+export const resetPassword = async (actionCode: string, newPassword: string) => {
+  const auth = firebase.auth();
+  try {
+    let response = auth.confirmPasswordReset(actionCode, newPassword)
+    //password has been confirmed and the new password updated
+    console.log(response);
+    // display a link back to the app or sign the user in directly
+    console.log("display a link back");
+  } catch(e) {
+    // code expired or password too weak 
+    throw Error(e.message);
+  }
+}

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -228,11 +228,9 @@ export const verifyActionCode = async (actionCode: string) => {
 export const resetPassword = async (actionCode: string, newPassword: string) => {
   const auth = firebase.auth();
   try {
-    let response = auth.confirmPasswordReset(actionCode, newPassword)
-    //password has been confirmed and the new password updated
-    console.log(response);
-    // display a link back to the app or sign the user in directly
-    console.log("display a link back");
+    await auth.confirmPasswordReset(actionCode, newPassword)
+    // password has been confirmed and the new password updated
+    return true;
   } catch(e) {
     // code expired or password too weak 
     throw Error(e.message);

--- a/src/shared/containers/header/Header.tsx
+++ b/src/shared/containers/header/Header.tsx
@@ -18,8 +18,7 @@ interface IHeader {
 }
 
 const Header: React.FC<IHeader> = ({ isLoggedIn }) => {
-
-
+  
   const Auth = useContext(AuthContext);
   let history = useHistory();
 

--- a/src/shared/features/HandleReset.tsx
+++ b/src/shared/features/HandleReset.tsx
@@ -16,7 +16,7 @@ import 'firebase/auth'; // for authentication
 import 'firebase/firestore'; // if database type is firestore, import this 
 import 'firebase/database'; // for additional user properties, like role 
 
-import { RouteComponentProps, useLocation } from 'react-router-dom'; // give us 'history' object
+import { RouteComponentProps, useLocation, Link } from 'react-router-dom'; // give us 'history' object
 import { Avatar } from "@material-ui/core";
 
 import { verifyActionCode, resetPassword } from 'services/user';
@@ -82,49 +82,55 @@ const HandleReset: React.FC<IHandleReset> = () => {
           <HelpIcon />
         </Avatar>
         <Typography component="h1" variant="h4">
-          Reset your password 
+          Enter a new password 
         </Typography>
         <p>for <b>{email}</b></p>
 
-        <p>mode: {mode}</p>
-        <p>action code: {actionCode}</p>
+        {!resetSent && 
+          <>
+          <form onSubmit={e => handleForm(e)} className="">
 
-        <form onSubmit={e => handleForm(e)} className="">
-
-        <Grid container spacing={2}>
-            {/* Display name */}
-            <Grid item xs={12}>
-              <TextField
-                autoComplete="email"
-                name="email"
-                variant="outlined"
-                required
-                fullWidth
-                id="email"
-                label="New password"
-                autoFocus
-                value={newPassword}
-                onChange={e => setNewPassword(e.target.value)}
-              />
+          <Grid container spacing={2}>
+              {/* Display name */}
+              <Grid item xs={12}>
+                <TextField
+                  autoComplete="email"
+                  name="email"
+                  variant="outlined"
+                  required
+                  fullWidth
+                  id="email"
+                  label="New password"
+                  autoFocus
+                  value={newPassword}
+                  onChange={e => setNewPassword(e.target.value)}
+                />
+              </Grid>
             </Grid>
-          </Grid>
 
-          <Button 
-            type="submit"
-            fullWidth
-            variant="contained"
-            color="primary"
-            size="large"
-            className="bigButton"
-          >
-            Save
-          </Button>
+            <Button 
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              size="large"
+              className="bigButton"
+            >
+              Save
+            </Button>
 
-        </form>
-        <span className="error">{error}</span>
-        {resetSent && 
-          <span>Password request sent</span>
+          </form>
+          <span className="error">{error}</span>
+          </>
         }
+
+        {resetSent && 
+          <>
+          <p>Password reset! You may log in.</p>
+          <Link to="/login">Click here to log in</Link>
+          </>
+        }
+      
       </div>
       <Box mt={8}>
         <Copyright />      

--- a/src/shared/features/HandleReset.tsx
+++ b/src/shared/features/HandleReset.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from "react";
+import * as QueryString from "query-string"
+
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Container from '@material-ui/core/Container';
+
+import Copyright from 'shared/components/Copyright';
+
+import HelpIcon from '@material-ui/icons/Help';
+
+import 'firebase/auth'; // for authentication
+import 'firebase/firestore'; // if database type is firestore, import this 
+import 'firebase/database'; // for additional user properties, like role 
+
+import { RouteComponentProps, useLocation } from 'react-router-dom'; // give us 'history' object
+import { Avatar } from "@material-ui/core";
+
+import { verifyActionCode, resetPassword } from 'services/user';
+
+interface MatchParams {
+  mode: string;
+}
+
+interface IHandleReset extends RouteComponentProps<MatchParams> {
+  props: RouteComponentProps;
+}
+
+/* This page is where we set the display name and account type */
+/* Separated from main Register page to make the Register page less overwhelming */
+
+const HandleReset: React.FC<IHandleReset> = () => {
+
+  const [email, setEmail] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [resetSent, setResetSent] = useState(false);
+
+  const [mode, setMode] = useState("");
+  const [actionCode, setActionCode] = useState("");
+
+  const [error, setErrors] = useState("");
+
+  const location = useLocation();
+
+  const params = QueryString.parse(location.search);
+
+  useEffect(() => {
+    verifyActionCode(params?.oobCode as string)
+      .then((email: string) => {
+        setEmail(email);
+      })
+      .catch((error) => {
+        setErrors(error.message);
+      })
+  }, []);
+
+  useEffect(() => {
+    setMode(params?.mode as string); // "resetPassword"
+    setActionCode(params?.oobCode as string); // long string
+  }, []);
+
+  /* ADD USER ROLE TYPE AND DISPLAY NAME TO USER SETTINGS */
+  const handleForm = async (e: any) => {
+    e.preventDefault();
+
+    try {
+      await resetPassword(actionCode, newPassword);
+      setResetSent(true);
+    } catch(e) {
+      setErrors(e.message);
+    }
+  }
+
+  return (
+    <Grid container>
+    <Container component="main" maxWidth="xs">
+      <div>
+        <Avatar className="formAvatar">
+          <HelpIcon />
+        </Avatar>
+        <Typography component="h1" variant="h4">
+          Reset your password 
+        </Typography>
+        <p>for <b>{email}</b></p>
+
+        <p>mode: {mode}</p>
+        <p>action code: {actionCode}</p>
+
+        <form onSubmit={e => handleForm(e)} className="">
+
+        <Grid container spacing={2}>
+            {/* Display name */}
+            <Grid item xs={12}>
+              <TextField
+                autoComplete="email"
+                name="email"
+                variant="outlined"
+                required
+                fullWidth
+                id="email"
+                label="New password"
+                autoFocus
+                value={newPassword}
+                onChange={e => setNewPassword(e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Button 
+            type="submit"
+            fullWidth
+            variant="contained"
+            color="primary"
+            size="large"
+            className="bigButton"
+          >
+            Save
+          </Button>
+
+        </form>
+        <span className="error">{error}</span>
+        {resetSent && 
+          <span>Password request sent</span>
+        }
+      </div>
+      <Box mt={8}>
+        <Copyright />      
+      </Box>
+    </Container>
+    </Grid>
+  );
+};
+
+export default HandleReset;

--- a/src/shared/features/HandleReset.tsx
+++ b/src/shared/features/HandleReset.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import * as QueryString from "query-string"
 
 import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
@@ -16,10 +15,13 @@ import 'firebase/auth'; // for authentication
 import 'firebase/firestore'; // if database type is firestore, import this 
 import 'firebase/database'; // for additional user properties, like role 
 
-import { RouteComponentProps, useLocation, Link } from 'react-router-dom'; // give us 'history' object
+import { useHistory, Link } from "react-router-dom";
+import { RouteComponentProps, useLocation } from 'react-router-dom'; // give us 'history' object
 import { Avatar } from "@material-ui/core";
 
 import { verifyActionCode, resetPassword } from 'services/user';
+import Alert from "@material-ui/lab/Alert";
+import BigInput from "shared/components/BigInput/BigInput";
 
 interface MatchParams {
   mode: string;
@@ -29,10 +31,9 @@ interface IHandleReset extends RouteComponentProps<MatchParams> {
   props: RouteComponentProps;
 }
 
-/* This page is where we set the display name and account type */
-/* Separated from main Register page to make the Register page less overwhelming */
-
 const HandleReset: React.FC<IHandleReset> = () => {
+
+  let history = useHistory();
 
   const [email, setEmail] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -46,6 +47,10 @@ const HandleReset: React.FC<IHandleReset> = () => {
   const location = useLocation();
 
   const params = QueryString.parse(location.search);
+
+  const updatePassword = (e: any) => {
+    setNewPassword(e.target.value);
+  }
 
   useEffect(() => {
     verifyActionCode(params?.oobCode as string)
@@ -62,80 +67,106 @@ const HandleReset: React.FC<IHandleReset> = () => {
     setActionCode(params?.oobCode as string); // long string
   }, []);
 
-  /* ADD USER ROLE TYPE AND DISPLAY NAME TO USER SETTINGS */
+  /* RESET PASSWORD */
   const handleForm = async (e: any) => {
     e.preventDefault();
 
     try {
       await resetPassword(actionCode, newPassword);
-      setResetSent(true);
+      setErrors("");
+      setResetSent(true); // hide form, display link back to login page 
     } catch(e) {
+      // possible errors include weak password and expired auth code 
       setErrors(e.message);
     }
   }
 
+  const goToLogin = () => {
+    console.log("going to login page");
+    history.replace('/login');
+  }
+
   return (
     <Grid container>
-    <Container component="main" maxWidth="xs">
-      <div>
-        <Avatar className="formAvatar">
-          <HelpIcon />
-        </Avatar>
-        <Typography component="h1" variant="h4">
-          Enter a new password 
-        </Typography>
-        <p>for <b>{email}</b></p>
-
-        {!resetSent && 
-          <>
-          <form onSubmit={e => handleForm(e)} className="">
-
+      <Container component="main" maxWidth="xs">
+        <br/>
+        {/* If the user arrives on this page with an invalid oobCode, don't show the form, just show the error message */}
+        {!email && 
           <Grid container spacing={2}>
-              {/* Display name */}
-              <Grid item xs={12}>
-                <TextField
-                  autoComplete="email"
-                  name="email"
-                  variant="outlined"
-                  required
-                  fullWidth
-                  id="email"
-                  label="New password"
-                  autoFocus
-                  value={newPassword}
-                  onChange={e => setNewPassword(e.target.value)}
-                />
-              </Grid>
+            <Grid item xs={12}>
+            {error &&
+              <Alert className="error" severity="error">{error}</Alert>
+            }
+            <br/>
+            <Link to="/resetPassword">Try again</Link>
             </Grid>
-
-            <Button 
-              type="submit"
-              fullWidth
-              variant="contained"
-              color="primary"
-              size="large"
-              className="bigButton"
-            >
-              Save
-            </Button>
-
-          </form>
-          <span className="error">{error}</span>
-          </>
+          </Grid>
         }
 
-        {resetSent && 
+        {email && 
           <>
-          <p>Password reset! You may log in.</p>
-          <Link to="/login">Click here to log in</Link>
-          </>
-        }
-      
-      </div>
-      <Box mt={8}>
-        <Copyright />      
-      </Box>
-    </Container>
+          <div>
+            {!resetSent && 
+              <>
+                <Avatar className="formAvatar">
+                  <HelpIcon />
+                </Avatar>
+                <Typography component="h1" variant="h4">
+                  Enter a new password 
+                </Typography>
+                <p>for <b>{email}</b></p>
+
+              <form onSubmit={e => handleForm(e)} className="">
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
+                    <BigInput 
+                      labelText="New password"
+                      name="password"
+                      required={true}
+                      value={newPassword}
+                      autoFocus={true}
+                      autoComplete="off"
+                      type="password"
+                      onChange={updatePassword}/>
+                    </Grid>
+                  </Grid>
+
+                  <Button 
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    size="large"
+                    className="bigButton"
+                  >
+                    Save
+                  </Button>
+                </form>
+              </>
+            }
+
+            {error &&
+              <Alert className="error" severity="error">{error}</Alert>
+            }
+
+            {resetSent && 
+              <>
+              <Typography component="h1" variant="h4">
+                  Success!
+                </Typography>
+              <p>Password for <b>{email}</b> has been reset.</p>
+              <Button className="bigButton" variant="contained" color="primary" onClick={() => {goToLogin()}}>Return to login</Button>
+              </>
+            }
+        
+        </div>
+        <Box mt={8}>
+          <Copyright />      
+        </Box>
+        </>
+      } {/* if email exists */ }
+
+      </Container>
     </Grid>
   );
 };

--- a/src/shared/features/Login.tsx
+++ b/src/shared/features/Login.tsx
@@ -120,7 +120,7 @@ const Login: React.FC<ILogin> = ({ history }) => {
           <Grid container justify="center">
 
             <Grid item xs={6}>
-              <Link href="#" className="bigLink">
+              <Link href="/resetPassword" className="bigLink">
                 Forgot password?
               </Link>
             </Grid>

--- a/src/shared/features/ResetPassword.tsx
+++ b/src/shared/features/ResetPassword.tsx
@@ -19,12 +19,12 @@ import { RouteComponentProps } from 'react-router-dom'; // give us 'history' obj
 import { Avatar } from "@material-ui/core";
 
 import { sendPasswordResetEmail } from 'services/user';
+import Alert from "@material-ui/lab/Alert";
+import BigInput from "shared/components/BigInput/BigInput";
 
 interface IResetPassword extends RouteComponentProps<any> {
+  // empty for now 
 }
-
-/* This page is where we set the display name and account type */
-/* Separated from main Register page to make the Register page less overwhelming */
 
 const ResetPassword: React.FC<IResetPassword> = () => {
 
@@ -33,14 +33,20 @@ const ResetPassword: React.FC<IResetPassword> = () => {
 
   const [error, setErrors] = useState("");
 
-  /* ADD USER ROLE TYPE AND DISPLAY NAME TO USER SETTINGS */
+  const updateEmailForReset = (e: any) => {
+    setEmailForReset(e.target.value);
+  }
+
+  /* REQUEST A PASSWORD RESET EMAIL BE SENT TO THIS EMAIL ADDRESS */
   const handleForm = async (e: any) => {
     e.preventDefault();
 
     try {
       await sendPasswordResetEmail(emailForReset);
+      setErrors("");
       setResetSent(true);
     } catch(e) {
+      // possible errors include email address doesn't exist in db 
       setErrors(e.message);
     }
   }
@@ -60,20 +66,16 @@ const ResetPassword: React.FC<IResetPassword> = () => {
         <form onSubmit={e => handleForm(e)} className="">
 
         <Grid container spacing={2}>
-            {/* Display name */}
             <Grid item xs={12}>
-              <TextField
-                autoComplete="email"
+              <BigInput 
+                labelText="E-Mail Address"
                 name="email"
-                variant="outlined"
-                required
-                fullWidth
-                id="email"
-                label="Your email address"
-                autoFocus
+                required={true}
                 value={emailForReset}
-                onChange={e => setEmailForReset(e.target.value)}
-              />
+                autoFocus={true}
+                autoComplete="current-email"
+                type="text"
+                onChange={updateEmailForReset}/>
             </Grid>
           </Grid>
 
@@ -89,9 +91,11 @@ const ResetPassword: React.FC<IResetPassword> = () => {
           </Button>
 
         </form>
-        <span className="error">{error}</span>
+        {error &&
+          <Alert className="error" severity="error">{error}</Alert>
+        }
         {resetSent && 
-          <span>E-mail sent! Check your inbox.</span>
+          <Alert severity="success">E-mail sent! Check your inbox.</Alert>
         }
       </div>
       <Box mt={8}>

--- a/src/shared/features/ResetPassword.tsx
+++ b/src/shared/features/ResetPassword.tsx
@@ -29,6 +29,7 @@ interface IResetPassword extends RouteComponentProps<any> {
 const ResetPassword: React.FC<IResetPassword> = () => {
 
   const [emailForReset, setEmailForReset] = useState("");
+  const [resetSent, setResetSent] = useState(false);
 
   const [error, setErrors] = useState("");
 
@@ -38,6 +39,7 @@ const ResetPassword: React.FC<IResetPassword> = () => {
 
     try {
       await sendPasswordResetEmail(emailForReset);
+      setResetSent(true);
     } catch(e) {
       setErrors(e.message);
     }
@@ -55,7 +57,7 @@ const ResetPassword: React.FC<IResetPassword> = () => {
         </Typography>
         <p>Enter your username and we’ll send a link to reset your password.</p>
 
-        <form onSubmit={e => handleForm(e)} className="" noValidate>
+        <form onSubmit={e => handleForm(e)} className="">
 
         <Grid container spacing={2}>
             {/* Display name */}
@@ -88,6 +90,9 @@ const ResetPassword: React.FC<IResetPassword> = () => {
 
         </form>
         <span className="error">{error}</span>
+        {resetSent && 
+          <span>E-mail sent! Check your inbox.</span>
+        }
       </div>
       <Box mt={8}>
         <Copyright />      

--- a/src/shared/features/ResetPassword.tsx
+++ b/src/shared/features/ResetPassword.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Container from '@material-ui/core/Container';
+
+import Copyright from 'shared/components/Copyright';
+
+import HelpIcon from '@material-ui/icons/Help';
+
+import 'firebase/auth'; // for authentication
+import 'firebase/firestore'; // if database type is firestore, import this 
+import 'firebase/database'; // for additional user properties, like role 
+
+import { RouteComponentProps } from 'react-router-dom'; // give us 'history' object
+import { Avatar } from "@material-ui/core";
+
+import { sendPasswordResetEmail } from 'services/user';
+
+interface IResetPassword extends RouteComponentProps<any> {
+}
+
+/* This page is where we set the display name and account type */
+/* Separated from main Register page to make the Register page less overwhelming */
+
+const ResetPassword: React.FC<IResetPassword> = () => {
+
+  const [emailForReset, setEmailForReset] = useState("");
+
+  const [error, setErrors] = useState("");
+
+  /* ADD USER ROLE TYPE AND DISPLAY NAME TO USER SETTINGS */
+  const handleForm = async (e: any) => {
+    e.preventDefault();
+
+    try {
+      await sendPasswordResetEmail(emailForReset);
+    } catch(e) {
+      setErrors(e.message);
+    }
+  }
+
+  return (
+    <Grid container>
+    <Container component="main" maxWidth="xs">
+      <div>
+        <Avatar className="formAvatar">
+          <HelpIcon />
+        </Avatar>
+        <Typography component="h1" variant="h4">
+          Reset password
+        </Typography>
+        <p>Enter your username and we’ll send a link to reset your password.</p>
+
+        <form onSubmit={e => handleForm(e)} className="" noValidate>
+
+        <Grid container spacing={2}>
+            {/* Display name */}
+            <Grid item xs={12}>
+              <TextField
+                autoComplete="email"
+                name="email"
+                variant="outlined"
+                required
+                fullWidth
+                id="email"
+                label="Your email address"
+                autoFocus
+                value={emailForReset}
+                onChange={e => setEmailForReset(e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Button 
+            type="submit"
+            fullWidth
+            variant="contained"
+            color="primary"
+            size="large"
+            className="bigButton"
+          >
+            Send e-mail
+          </Button>
+
+        </form>
+        <span className="error">{error}</span>
+      </div>
+      <Box mt={8}>
+        <Copyright />      
+      </Box>
+    </Container>
+    </Grid>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
**Custom password reset user flow**
NOTE: ONLY WORKS ON LOCALHOST:3000 UNTIL FIREBASE LINK TEMPLATE IS UPDATED. If you run your development instance of the app on anything but localhost:3000 it won't work for you locally. 

Firebase's built-in password reset feature is very bare-bones, so this is a custom implementation of the various UI steps: 
1. Submit an email address to get a password reset email (if the email address does not exist, the form will tell you so)
2. Click the link that is emailed to you
3. Choose a password (if the password is too short, the form will tell you so)
4. Submit the new password
5. Click the link to return to the Login page 

The link that is sent to your email address is set in the Firebase Auth console. It can only be set to one URL at a time. To facilitate local testing, that template url starts with http://localhost:3000 

Once this PR is approved and the code is merged into master and deployed to Heroku, that localhost url in the template should be updated to https://holaoma.herokuapp.com 

This also means that resetting a password will only work via the app running on holaoma.herokuapp.com, not when it's running on localhost. (This "limitation" is from Firebase.)