### PR TITLE
UI touchups for Midpoint

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -49,7 +49,7 @@ input {
 .bigButton {
   height:100px;
   font-size:1.8em !important;
-  margin-top:30px !important;
+  margin-top:10px !important;
   margin-bottom:30px !important;
 }
 

--- a/src/shared/features/GrandparentViews/Inbox/Inbox.tsx
+++ b/src/shared/features/GrandparentViews/Inbox/Inbox.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useState} from 'react';
 import { useHistory } from "react-router-dom";
 import { makeStyles } from '@material-ui/core/styles';
 
-import {Container, Grid, Card, CardHeader, CardContent, Box} from '@material-ui/core';
+import {Container, Grid, Card, CardHeader, CardContent, Box, Typography} from '@material-ui/core';
 import MailIcon from '@material-ui/icons/Mail';
 import DraftsIcon from '@material-ui/icons/Drafts';
 
@@ -65,22 +65,29 @@ const Inbox: React.FC<IInbox> = ({ posts }) => {
   return (
     <>
       <Container>
-        <Grid container>
-          {posts.map((post: Post, index: number) => {
-            return (
-              <div className={"inboxCard"} key={index} onClick={() => pressEnvelope(post)} >
-                <Card className={classes.root} variant="outlined">
-                  <CardHeader
-                    title={post.from}>
-                  </CardHeader>
-                  <CardContent>
-                    {post.read? <DraftsIcon className="icon"/> : <MailIcon className="icon"/>}
-                  </CardContent>
-                </Card>
-              </div>
+        <Grid container direction="row" justify="flex-start">
+            {posts.map((post: Post, index: number) => {
+              return (
+                <Grid item justify="flex-start">
+                  <div className={"inboxCard"} key={index} onClick={() => pressEnvelope(post)} >
+                    <Card className={classes.root} variant="outlined">
+                      <CardContent>
+                        <Typography className={classes.title} color="textSecondary" gutterBottom>
+                          From
+                        </Typography>
+
+                        <Typography variant="h5" component="h2">
+                          {post.from}
+                        </Typography>
+
+                          {post.read? <DraftsIcon style={{ fontSize: 70 }}/> : <MailIcon style={{ fontSize: 70 }}/>}
+                          {post.read? <p><i>Read</i></p> : <p><b>New!</b></p>}
+                      </CardContent>
+                    </Card>
+                  </div>
+                </Grid>
             )
           })
-
           }
         </Grid>
 

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { Container, Grid, Card, CardHeader, CardContent, CardMedia, Typography } from '@material-ui/core';
+import { Container, Grid, Card, CardHeader, CardContent, CardMedia, Typography, Button } from '@material-ui/core';
 import Alarm from '@material-ui/icons/Alarm';
 import { Link } from 'react-router-dom';
 
@@ -53,20 +53,15 @@ const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
 
   return (
     <Container>
-      <Container>
-          <Link to={"/newPost"}>
-            <Card>
-                <CardContent>
-                    Make a new post
-                </CardContent>
-            </Card>
-          </Link>
-      </Container>
+      <Typography component="h2" variant="h5">
+        Posts
+      </Typography>
+
       <Grid container spacing={2}>
         {
           posts.map((post: Post, index: number) => {
             return (
-              <Grid item xs={4} key={index}>
+              <Grid item xs={12} sm={4} key={index}>
                 <div>
                   <Link to={{
                     pathname: "/postDetails",

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -65,7 +65,7 @@ const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
           posts.map((post: Post, index: number) => {
             return (
               <Grid item xs={12} sm={4} key={index}>
-                <div>
+                <div className={"postStyle"}>
                   <Link to={{
                     pathname: "/postDetails",
                     state: {post: post}

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -5,7 +5,7 @@ import {roles} from '../../../enums/enums';
 import {getUserSettings} from "services/user";
 import Inbox from '../GrandparentViews/Inbox/Inbox';
 import PostManagement from '../PostManagement/PostManagement';
-import { Link as ButtonLink} from '@material-ui/core';
+import { Link as ButtonLink, Button, Grid, Container, Typography} from '@material-ui/core';
 import {getPosts} from 'services/post';
 
 import {Post} from '../../models/post.model';
@@ -14,16 +14,20 @@ import {acceptLink, getLinkedAccounts} from 'services/accountLink';
 import {Link} from 'react-router-dom';
 import {AccountLink} from 'shared/models/accountLink.model';
 
+import { RouteComponentProps } from 'react-router-dom'; // give us 'history' object
+
 import PendingInvitationModal from './components/PendingInvitationModal';
 
 import Alert from '@material-ui/lab/Alert';
 
+import PersonAddIcon from '@material-ui/icons/PersonAdd';
+import AddCommentIcon from '@material-ui/icons/AddComment';
 
-interface IPostsView {
+interface IPostsView extends RouteComponentProps<any> {
   setIsLoading: (loading: boolean) => void;
 }
 
-const PostsView: React.FC<IPostsView> = ({ setIsLoading }) => {
+const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
 
   const [displayName, setDisplayName] = useState("");
   const [role, setRole] = useState("");
@@ -92,13 +96,63 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading }) => {
     setInvitationModalOpen(false);
   }
 
-  return (
-    <>
-    <h1>Welcome, {displayName}!</h1>
+  const handleInviteButton = () => {
+    if (history) history.push('/addAccountLink');
+  }
 
-    {role === roles.poster &&
-      <Link to="/addAccountLink">Invite someone</Link>
-    }
+  const goToNewPost = () => {
+    if (history) history.push('/newPost')
+  }
+
+  return (
+    <Container>
+      <Grid container justify="center">
+
+        <Grid item xs>{/* Intentionally empty */}</Grid>
+
+        <Grid item xs={6}>
+          <Typography component="h1" variant="h4">
+            Welcome, {displayName}!
+          </Typography>
+          <p>You have 0 new {role === roles.poster ? 'replies' : 'letters'}.</p>
+        </Grid>
+
+        {role === roles.poster &&
+          <Grid item xs justify="flex-end" alignItems="center" style={{display: 'flex'}}>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              onClick={handleInviteButton}
+              startIcon={<PersonAddIcon />}
+            >
+              Invite follower
+            </Button>
+          </Grid>
+        }
+
+        {role === roles.receiver && 
+          <Grid item xs>{/* Intentionally left empty so the user's name centers*/}</Grid>
+        }
+
+        {role === roles.poster &&
+          <>
+            <Grid item xs={12} alignItems="baseline">
+              <Button
+                  variant="contained"
+                  color="secondary"
+                  size="large"
+                  className="bigButton"
+                  onClick={goToNewPost}
+                  startIcon={<AddCommentIcon />}
+                >
+                  Create New Post
+              </Button>
+            </Grid>
+          </>
+        }
+      </Grid>
+      <hr />
 
     {role === roles.poster &&
       <>
@@ -135,8 +189,7 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading }) => {
 
     {role === roles.poster && <PostManagement posts={posts}/>}
     {role === roles.receiver && <Inbox posts={posts}/>}
-
-    </>
+    </Container>
   )
 }
 

--- a/src/shared/features/SettingsView/SettingsView.tsx
+++ b/src/shared/features/SettingsView/SettingsView.tsx
@@ -161,8 +161,6 @@ const SettingsView: React.FC<ISettingsView> = ({ history, setIsLoading }) => {
         <Box className="todo">
         <h3>To do items:</h3>
         <ul>
-          <li>Make this page look less like the login/register pages</li>
-          <li>Change role should have a confirmation of some sort</li>
           <li>Fade out removed invites/deleted friends</li>
           <li>[Stretch goal] Friend profile pics?</li>
         </ul>


### PR DESCRIPTION
- Moves "Invite followers" to a button, moves it away from the "create new post" button 
- Gives "Create new post" button a color so it stands out from the posts
- Adds a "Posts" title over the created posts section to separate it from the top section 
- Adds a "You have X replies/new letters" string that is just a string for now but could later be updated to display the count of replies or new letters (just a summary of what's new for the user) 

<img width="1300" alt="Screenshot 2020-05-02 10 24 33" src="https://user-images.githubusercontent.com/5402322/80869156-4e824580-8c64-11ea-8c50-f03fcd916e3c.png">

- Increases the size of the inbox envelope icons 
- Adds "From" label
- Adds "New/Read" badging below envelope icon
<img width="1220" alt="Screenshot 2020-05-02 10 41 40" src="https://user-images.githubusercontent.com/5402322/80869173-6bb71400-8c64-11ea-83e3-234be2a89e6d.png">

- Improves the presentation of the posts on very narrow screen sizes (they switch to being "full width") 

<img width="459" alt="Screenshot 2020-05-02 10 47 04" src="https://user-images.githubusercontent.com/5402322/80869202-a8830b00-8c64-11ea-824d-782e88980bc4.png">
