### PR TITLE
Family side replies plus some styling

### DIFF
--- a/src/services/reply.ts
+++ b/src/services/reply.ts
@@ -65,7 +65,7 @@ export const createReplyDocument = async (reply: Reply) => {
 
 export const updateReplyID = async (replyID: string) => {
   const db = firebase.firestore();
-  await db.collection("posts").doc(replyID).update({
+  await db.collection("replies").doc(replyID).update({
     "rid": replyID,
   })
     .then(function() {
@@ -116,4 +116,39 @@ export const uploadPhoto = async (photoData: string) => {
       throw Error(e.message);
     }
   });
+}
+
+export const getRepliesToPost = async (postId: string): Promise<Reply[]> => {
+  const db = firebase.firestore();
+  const replies: Array<Reply> = [];
+
+  try {
+    const replyRef = db.collection('replies')
+      .where("responseTo", "==", postId)
+      .orderBy("date", "desc")
+    replyRef.onSnapshot(snapshot => {          // listen for state change
+      const currentReplies: Reply[] = [];
+      snapshot.forEach(doc => {
+        // console.log(doc.id, '->', doc.data());
+        const reply = doc.data();
+        currentReplies.push({
+          date: reply.date,
+          creatorID: reply.creatorID,
+          from: reply.from,
+          read: reply.read,
+          replyType: reply.replyType,
+          message: reply.message,
+          responseTo: reply.responseTo,
+          receiverID: reply.receiverID,
+          rid: reply.rid
+        })
+      })
+      replies.length = 0;      // Clear array so items not appended on state change
+      replies.push(...currentReplies);
+    })
+  } catch (error) {
+    console.error(error);
+  }
+  console.log(replies);
+  return replies;
 }

--- a/src/services/reply.ts
+++ b/src/services/reply.ts
@@ -149,6 +149,5 @@ export const getRepliesToPost = async (postId: string): Promise<Reply[]> => {
   } catch (error) {
     console.error(error);
   }
-  console.log(replies);
   return replies;
 }

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -7,6 +7,7 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { Post } from 'shared/models/post.model';
 import { getLinkedAccounts } from "services/accountLink";
 import { deletePost } from "services/post";
+import { getRepliesToPost } from "services/reply";
 
 
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
@@ -100,6 +101,9 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                 }
             }
             setReceivers(rcvrs);
+        });
+        getRepliesToPost(post.pid).then((replies) => {
+            console.log(replies);
         });
     }, []); // fires on page load if this is empty [] 
 

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -128,7 +128,7 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
     return (
         <>
         <Container>
-            <Typography variant="h3">
+            <Typography component="h2" variant="h5">
                 Sent Message
             </Typography>
         </Container>
@@ -185,55 +185,56 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                 </Button>
             </Grid>
         </Grid>
+        <Container>
+            <hr />
+            <Typography component="h2" variant="h5">
+                Replies
+            </Typography>
+                <Grid container spacing={2}>
+                {
+                replies.map((reply: Reply, index: number) => {
+                    return (
+                    <Grid item xs={4} key={index}>
+                        <div>
+                        <div onClick={()=>handleClick(reply)}>
+                        <Card variant="outlined">
+                            <CardContent>
+                                {isEmoji(reply) &&
+                                    messageAsArray(reply).map((emojiIndex: number, replyIndex: number) => {
+                                        return (
+                                            <Typography variant="h5" key={replyIndex}>
+                                                {emojiIcons[emojiIndex]}
+                                            </Typography>
+                                        )
+                                    })
+                                }
+                                <Typography variant="subtitle2">
+                                    Sent by {reply.from}
+                                    <br/>
+                                    <Moment format="MMMM Do YYYY, h:mm a">{reply.date}</Moment>
+                                </Typography>
+                            </CardContent>
+                        </Card>
+                        </div>
+                        </div>
+                    </Grid>
+                    )
+                })
+                }
+            </Grid>
+            <Modal open={modalOpen} onClose={handleClick} style={{display:'flex',alignItems:'center',justifyContent:'center'}}>
+            <div className={classes.paper}>
+                {modalReply && <ModalReply reply={modalReply}/>}
+            </div>
+            </Modal>
+        </Container>
 
-        <Typography variant="h3">
-            Replies
-        </Typography>
-
-            <Grid container spacing={2}>
-            {
-            replies.map((reply: Reply, index: number) => {
-                return (
-                <Grid item xs={4} key={index}>
-                    <div>
-                    <div onClick={()=>handleClick(reply)}>
-                    <Card variant="outlined">
-                        <CardContent>
-                            {isEmoji(reply) &&
-                                messageAsArray(reply).map((emojiIndex: number, replyIndex: number) => {
-                                    return (
-                                        <Typography variant="h5" key={replyIndex}>
-                                            {emojiIcons[emojiIndex]}
-                                        </Typography>
-                                    )
-                                })
-                            }
-                            <Typography variant="subtitle2">
-                                Sent by {reply.from}
-                                <br/>
-                                <Moment format="MMMM Do YYYY, h:mm a">{reply.date}</Moment>
-                            </Typography>
-                        </CardContent>
-                    </Card>
-                    </div>
-                    </div>
-                </Grid>
-                )
-            })
-            }
-        </Grid>
-        <Modal open={modalOpen} onClose={handleClick} style={{display:'flex',alignItems:'center',justifyContent:'center'}}>
-        <div className={classes.paper}>
-            {modalReply && <ModalReply reply={modalReply}/>}
-        </div>
-        </Modal>
-
-         <Box className="todo">
+        <Box className="todo">
             <h3>To do items:</h3>
             <ul>
-                <li>Display responses associated with this post.</li>
                 <li>Break out seen by by individual receiver "read" receipts - After post model has been changed to accommodate.</li>
                 <li>Edit/delete options?</li>
+                <li>Send a short video</li>
             </ul>
         </Box>
      </>

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -30,25 +30,6 @@ const useStyles = makeStyles((theme: Theme) =>
       border: '2px solid #000',
       boxShadow: theme.shadows[5],
       padding: theme.spacing(2, 4, 3),
-    },
-    root: {
-        minWidth: 250,
-        maxWidth: 250
-    },
-    bullet: {
-        display: 'inline-block',
-        margin: '0 2px',
-        transform: 'scale(0.8)',
-    },
-    title: {
-        fontSize: 16,
-    },
-    pos: {
-        marginBottom: 12,
-    },
-    media: {
-        height: 300,
-        maxWidth: "100%"
     }
   })
 );

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -7,7 +7,7 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { Post } from 'shared/models/post.model';
 import { getLinkedAccounts } from "services/accountLink";
 import { deletePost } from "services/post";
-import { getRepliesToPost } from "services/reply";
+import { getRepliesToPost, markReplyRead } from "services/reply";
 import { Reply } from "../../models/reply.model";
 import { replyEmojiArray } from "../../../Icons";
 
@@ -96,8 +96,11 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
             }
             setReceivers(rcvrs);
         });
-        getRepliesToPost(post.pid).then((replies) => {
-            setReplies(replies);
+        getRepliesToPost(post.pid).then((replyArray: any) => {
+            setReplies(replyArray);
+            for (let i = 0; i < replyArray.length; i++) {
+                markReplyRead(replyArray[i].rid);
+            }
         });
     }, []); // fires on page load if this is empty [] 
 
@@ -197,9 +200,9 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                     <Card variant="outlined">
                         <CardContent>
                             {isEmoji(reply) &&
-                                messageAsArray(reply).map((emojiIndex: number) => {
+                                messageAsArray(reply).map((emojiIndex: number, replyIndex: number) => {
                                     return (
-                                        <Typography variant="h5">
+                                        <Typography variant="h5" key={replyIndex}>
                                             {emojiIcons[emojiIndex]}
                                         </Typography>
                                     )

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -10,7 +10,7 @@ import { deletePost } from "services/post";
 import { getRepliesToPost, markReplyRead } from "services/reply";
 import { Reply } from "../../models/reply.model";
 import { replyEmojiArray } from "../../../Icons";
-
+import ModalReply from "./ModalReply";
 
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
@@ -224,7 +224,7 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
         </Grid>
         <Modal open={modalOpen} onClose={handleClick} style={{display:'flex',alignItems:'center',justifyContent:'center'}}>
         <div className={classes.paper}>
-            {modalReply && modalReply.message}
+            {modalReply && <ModalReply reply={modalReply}/>}
         </div>
         </Modal>
 

--- a/src/shared/features/FamilyMsgView/ModalReply.tsx
+++ b/src/shared/features/FamilyMsgView/ModalReply.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { Typography, Container } from '@material-ui/core';
+
+import { Reply } from "../../models/reply.model";
+import { replyEmojiArray } from "../../../Icons";
+
+interface IReply {
+    // add posts as Post model here
+    // For now, I made it a number to show how you might loop through a quantity of things passed in
+    reply: Reply; // array of type "Post"
+  }
+
+const ModalReply: React.FC<IReply> = ({reply}) => {
+
+    const emojiIcons = replyEmojiArray();
+
+    const messageAsArray = (reply: Reply) => {
+        return reply.message as number[];
+    }
+    
+    const isEmoji = (reply: Reply) => {
+        return (reply.replyType === "emoji" && typeof reply.message !== "string");
+    }
+
+    if (isEmoji(reply)) {
+        return (
+            <>
+                {
+                    messageAsArray(reply).map((emojiIndex: number, replyIndex: number) => {
+                        return (
+                            <Container>
+                                {emojiIcons[emojiIndex]}
+                            </Container>
+                        )
+                    })
+                }
+            </>
+        )
+    } else {
+        return (
+            <>
+            </>
+        )
+    }
+};
+
+export default ModalReply;

--- a/src/shared/features/GrandparentViews/GrandparentReply/components/GetEmojiReply.tsx
+++ b/src/shared/features/GrandparentViews/GrandparentReply/components/GetEmojiReply.tsx
@@ -74,7 +74,7 @@ const GetEmojiReply: React.FC<IEmojiReply> = ({isOpen, returnToPost}) => {
     else {
       setAlert(false);
       const replyContent: Reply = setReplyContent(userId, displayName, REPLY_TYPES.EMOJI,
-                                  choicesIndexes, FamilyPost.from, FamilyPost.creatorID);
+                                  choicesIndexes, FamilyPost.pid, FamilyPost.creatorID);
       submitReply(e, replyContent)
         .then( () => { history.push({pathname: "/newReply",  state: replyContent}); } );
     }

--- a/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
+++ b/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
@@ -7,6 +7,7 @@ import { createPost, updatePostID, uploadFile } from "services/post";
 import { getUserProfile } from "services/user";
 import { getLinkedAccounts } from "services/accountLink";
 import Alert from '@material-ui/lab/Alert';
+import ClearIcon from '@material-ui/icons/Clear';
 
 import './NewFamilyPost.css';
 // @ts-ignore
@@ -81,6 +82,13 @@ const NewFamilyPost: React.FC = () => {
         setReceivers(newArray);
     }
 
+    const clickFileUpload = () => {
+        let element = document.getElementById("file-upload");
+        if (element != null) {
+            element.click();
+        }
+    }
+
     const onSelect = (file: File | null) => {
         if (file) {
             Resizer.imageFileResizer(
@@ -126,11 +134,31 @@ const NewFamilyPost: React.FC = () => {
     return (
         <>
         <form className="newFamilyPostForm" noValidate onSubmit={e => submitPost(e)}>
-        <Box>
-            <input
-                type="file"
-                onChange={(event) => onSelect(event.target.files ? event.target.files[0] : null)} />
-        </Box>
+        {!selectedFile &&
+            <Box>
+                <Button
+                    variant="outlined"
+                    color="secondary"
+                    size="small"
+                    onClick={clickFileUpload}>
+                    Select a photo
+                </Button>
+                <input
+                    type="file"
+                    id="file-upload"
+                    style={{display:'none'}}
+                    onChange={(event) => onSelect(event.target.files ? event.target.files[0] : null)} />
+            </Box>
+        }
+        {selectedFile && 
+            <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                onClick={() => setSelectedFile(null)}>
+                <ClearIcon/>Remove file
+            </Button>
+        }
         <TextField
             multiline
             fullWidth

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles({
   },
   postStyle: {
     height: "100%"
+  },
+  postBottom: {
+    maxHeight: 90
   }
 });
 
@@ -81,7 +84,7 @@ const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
         {
           posts.map((post: Post, index: number) => {
             return (
-              <Grid item xs={12} sm={4} key={index}>
+              <Grid item xs={12} sm={6} md={4} key={index}>
                 <div className={"postStyle"}>
                   <Link to={{
                     pathname: "/postDetails",
@@ -104,7 +107,7 @@ const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
                           </Typography>
                       </Grid>
 
-                      <Grid item>
+                      <Grid item className={classes.postBottom}>
                           <Grid container justify={"space-between"}>
                             <Grid item xs={5}>
                                 <Typography variant="subtitle2">

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -26,24 +26,28 @@ const useStyles = makeStyles({
 
 interface IPostManagement {
   posts: Array<Post>; // array of type "Post"
+  onNewReplies: any
 }
 
-const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
+const PostManagement: React.FC<IPostManagement> = ({ posts, onNewReplies }) => {
 
   const classes = useStyles();
   const [newReplies, setNewReplies] = useState<boolean[]>([]);
 
   useEffect(() => {
+    let numNewReplies = 0;
     for (let i = 0; i < posts.length; i++) {
+      // eslint-disable-next-line no-loop-func
       getRepliesToPost(posts[i].pid).then((replyArray: any) => {
         let newRep = false;
         for (let j = 0; j < replyArray.length; j++) {
           if (replyArray[j].read === false) {
             newRep = true;
-            break;
+            numNewReplies++;
           }
         }
         setNewReplies(newReplies => newReplies.concat(newRep));
+        onNewReplies(numNewReplies);
       });
     }
 }, []); // fires on page load if this is empty [] 

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
 import { Container, Grid, Card, CardMedia, Typography } from '@material-ui/core';
@@ -6,6 +6,7 @@ import Alarm from '@material-ui/icons/Alarm';
 import { Link } from 'react-router-dom';
 
 import { Post } from 'shared/models/post.model';
+import { getRepliesToPost } from "services/reply";
 
 import Moment from 'react-moment';
 
@@ -45,6 +46,22 @@ interface IPostManagement {
 const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
 
   const classes = useStyles();
+  const [newReplies, setNewReplies] = useState<boolean[]>([]);
+
+  useEffect(() => {
+    for (let i = 0; i < posts.length; i++) {
+      getRepliesToPost(posts[i].pid).then((replyArray: any) => {
+        let newRep = false;
+        for (let j = 0; j < replyArray.length; j++) {
+          if (replyArray[j].read === false) {
+            newRep = true;
+            break;
+          }
+        }
+        setNewReplies(newReplies => newReplies.concat(newRep));
+      });
+    }
+}, []); // fires on page load if this is empty [] 
 
   const getMessageSubstring = function(message: string) {
     if (message.length > 100) {
@@ -96,12 +113,14 @@ const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
                                     <Moment format="MMMM Do YYYY">{post.date}</Moment>
                                 </Typography>
                             </Grid>
-                            <Grid item xs={5}>
+                            {newReplies[index] === true &&
+                              <Grid item xs={5}>
                                 <Alarm className="icon"/>
                                 <Typography variant="subtitle2">
-                                    New replies!
+                                  New replies!
                                 </Typography>
-                            </Grid>
+                              </Grid>
+                            }
                           </Grid>
                       </Grid>
                     </Grid>

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -13,21 +13,6 @@ import Moment from 'react-moment';
 import './PostManagement.css';
 
 const useStyles = makeStyles({
-  root: {
-    minWidth: 250,
-    maxWidth: 250
-  },
-  bullet: {
-    display: 'inline-block',
-    margin: '0 2px',
-    transform: 'scale(0.8)',
-  },
-  title: {
-    fontSize: 16,
-  },
-  pos: {
-    marginBottom: 12,
-  },
   media: {
     height: '140px'
   },
@@ -40,12 +25,9 @@ const useStyles = makeStyles({
 });
 
 interface IPostManagement {
-  // add posts as Post model here
-  // For now, I made it a number to show how you might loop through a quantity of things passed in
   posts: Array<Post>; // array of type "Post"
 }
 
-// todo: pass "Posts" into this functional component
 const PostManagement: React.FC<IPostManagement> = ({ posts }) => {
 
   const classes = useStyles();

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { Container, Grid, Card, CardHeader, CardContent, CardMedia, Typography, Button } from '@material-ui/core';
+import { Container, Grid, Card, CardMedia, Typography } from '@material-ui/core';
 import Alarm from '@material-ui/icons/Alarm';
 import { Link } from 'react-router-dom';
 

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -119,7 +119,7 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
           <Typography component="h1" variant="h4">
             Welcome, {displayName}!
           </Typography>
-          <p>You have {numNewReplies} new {role === roles.poster ? 'replies' : 'letters'}.</p>
+          <p>You have {numNewReplies} new {role === roles.poster ? (numNewReplies !== 1 ? 'replies' : 'reply') : 'letters'}.</p>
         </Grid>
 
         {role === roles.poster &&

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -36,6 +36,7 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
   const [pendingInvitations, setPendingInvitations] = useState<AccountLink[]>([]);
   const [invite, setInvite] = useState<AccountLink>();
   const [invitationModalOpen, setInvitationModalOpen] = useState<boolean>(false);
+  const [numNewReplies, setNumNewReplies] = useState(0);
 
   const updatePendingInvitations = (dataArr: AccountLink[]) => {
     if (dataArr.length > 0) {
@@ -104,6 +105,10 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
     if (history) history.push('/newPost')
   }
 
+  const updateNewReplies = (num: number) => {
+    setNumNewReplies(num);
+  }
+
   return (
     <Container>
       <Grid container justify="center">
@@ -114,7 +119,7 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
           <Typography component="h1" variant="h4">
             Welcome, {displayName}!
           </Typography>
-          <p>You have 0 new {role === roles.poster ? 'replies' : 'letters'}.</p>
+          <p>You have {numNewReplies} new {role === roles.poster ? 'replies' : 'letters'}.</p>
         </Grid>
 
         {role === roles.poster &&
@@ -187,7 +192,7 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
       </>
     }
 
-    {role === roles.poster && <PostManagement posts={posts}/>}
+    {role === roles.poster && <PostManagement posts={posts} onNewReplies={updateNewReplies}/>}
     {role === roles.receiver && <Inbox posts={posts}/>}
     </Container>
   )


### PR DESCRIPTION
- Gets replies and displays emojis
- Marks replies as read
- Connect alert for new replies on individual posts
- Connect number of new replies at top of main page
- Sent and alert messages sit flush with the bottom of the card
- Add a divider between post and replies
- Replace file input on create post page with a button
- Give user the option to remove a file they've selected

If we have time I'd like to make the emojis appear more like they do on Facebook rather than showing up in their own little card and modal. For now, proceeding with what's in our mockups and will reassess in a week or two.

Known issue: If a reply was created before a reply id was added (part of this PR), it's not marked as read and shows up as a new reply.