### PR TITLE
Limit displayName length, improvements to displaying long names

### DIFF
--- a/src/shared/features/PostsView/PostsView.css
+++ b/src/shared/features/PostsView/PostsView.css
@@ -1,0 +1,3 @@
+.welcomeName {
+  text-align:center;
+}

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -27,6 +27,8 @@ import Column from 'shared/components/Column/Column';
 import Child from 'shared/components/Child/Child';
 import Row from 'shared/components/Row/Row';
 
+import './PostsView.css';
+
 interface IPostsView extends RouteComponentProps<any> {
   setIsLoading: (loading: boolean) => void;
 }
@@ -130,9 +132,11 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
   }
 
   const welcomeName = () => (
-    <span className="boldText">
-      Welcome, {displayName}!
-    </span>
+    <div className="welcomeName">
+      <span className="boldText">
+        Welcome, {displayName}!
+      </span>
+    </div>
   )
 
   const inviteButton = () => (

--- a/src/shared/features/RegisterDetails.tsx
+++ b/src/shared/features/RegisterDetails.tsx
@@ -109,7 +109,12 @@ const RegisterDetails: React.FC<IRegisterDetails> = ({ history, setIsLoading }) 
     e.preventDefault();
 
     if (displayName === "") {
-      setErrors("Please enter a name");
+      setErrors("Please enter a name.");
+      setInvalidName(true);
+    } else if (displayName.length > 34) {
+      // 34 character test name with spaces: Priscilla Jacqueline Flarblesworth
+      // 34 character word with no spaces: Supercalifragilisticexpialidocious
+      setErrors("Please enter a shorter name.");
       setInvalidName(true);
     } else {
       try {

--- a/src/shared/features/SettingsView/SettingsView.tsx
+++ b/src/shared/features/SettingsView/SettingsView.tsx
@@ -5,12 +5,10 @@ import { RouteComponentProps } from 'react-router-dom'; // give us 'history' obj
 import { getUserSettings, updateUserSettings, getUserProfile, updateUserProfile } from '../../../services/user';
 
 import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { Box } from '@material-ui/core';
 
 import BigInput from 'shared/components/BigInput/BigInput';
-import LinkedAccountManagement from './components/LinkedAccountManagement';
+import LinkedAccountManagement from './components/LinkedAccountManagement/LinkedAccountManagement';
 
 import './SettingsView.css';
 import ChangeAccountTypeAlert from './components/ChangeAccountTypeAlert';
@@ -18,8 +16,6 @@ import CredentialsWrapper from 'shared/components/CredentialsWrapper';
 import Row from 'shared/components/Row/Row';
 import Column from 'shared/components/Column/Column';
 import Child from 'shared/components/Child/Child';
-import FormSubmitButton from 'shared/components/FormSubmitButton';
-import FormError from 'shared/components/FormError/FormError';
 import CredentialsForm from 'shared/components/CredentialsForm/CredentialsForm';
 
 interface ISettingsView extends RouteComponentProps<any>{
@@ -34,6 +30,7 @@ const SettingsView: React.FC<ISettingsView> = ({ history, setIsLoading }) => {
   const [changeAccountTypeAlertOpen, setChangeAccountTypeAlertOpen] = useState<boolean>(false);
 
   const [error, setErrors] = useState("");
+  const [invalidName, setInvalidName] = useState(false);
 
   const updateDisplayName = (e: any) => {
     setDisplayName(e.target.value);
@@ -58,7 +55,7 @@ const SettingsView: React.FC<ISettingsView> = ({ history, setIsLoading }) => {
 
   const displayNameInput = () => (
     <BigInput 
-      error={false}
+      error={invalidName}
       labelText="Display Name"
       name="displayName"
       required={true} 
@@ -86,15 +83,24 @@ const SettingsView: React.FC<ISettingsView> = ({ history, setIsLoading }) => {
   const handleForm = async (e: any) => {
     e.preventDefault();
 
-    try {
-      let updateProfileDone = await updateUserProfile(displayName, email);
-      let updateSettingsDone = await updateUserSettings({role, displayName, email});
+    if (displayName === "") {
+      setErrors("Please enter a name.");
+      setInvalidName(true);
+    } else if (displayName.length > 34) {
+      // 34 character test name with spaces: Priscilla Jacqueline Flarblesworth
+      setErrors("Please enter a shorter name.");
+      setInvalidName(true);
+    } else {
+      try {
+        let updateProfileDone = await updateUserProfile(displayName, email);
+        let updateSettingsDone = await updateUserSettings({role, displayName, email});
 
-      if (updateProfileDone && updateSettingsDone) {
-        if (history) history.push('/posts');
+        if (updateProfileDone && updateSettingsDone) {
+          if (history) history.push('/posts');
+        }
+      } catch(e) {
+        setErrors(e.message);
       }
-    } catch(e) {
-      setErrors(e.message);
     }
   }
 

--- a/src/shared/features/SettingsView/components/LinkedAccountManagement/LinkedAccountManagement.css
+++ b/src/shared/features/SettingsView/components/LinkedAccountManagement/LinkedAccountManagement.css
@@ -1,0 +1,7 @@
+.breakLongName {
+  word-wrap:break-word;
+}
+
+.noRight {
+  right:0px !important;
+}

--- a/src/shared/features/SettingsView/components/LinkedAccountManagement/LinkedAccountManagement.tsx
+++ b/src/shared/features/SettingsView/components/LinkedAccountManagement/LinkedAccountManagement.tsx
@@ -4,8 +4,11 @@ import { Box, List, ListItem, ListItemAvatar, Avatar, ListItemText, ListItemSeco
 import { roles } from 'enums/enums';
 
 import PersonIcon from '@material-ui/icons/Person';
-import ManageAccountLinkAlert from './ManageAccountLinkAlert';
+import ManageAccountLinkAlert from '../ManageAccountLinkAlert';
 import { acceptLink, removeLink, getLinkedAccounts } from 'services/accountLink';
+
+import './LinkedAccountManagement.css';
+import Child from 'shared/components/Child/Child';
 
 interface ILinkedAccountManagement {
   role: string;
@@ -153,14 +156,18 @@ const LinkedAccountManagement: React.FC<ILinkedAccountManagement> = ({ role }) =
             </ListItemAvatar>
 
             {/* Text */}
-            <ListItemText
-              primary={showPrimaryText(friend)}
-              secondary={showSecondaryText(friend)}
-            />
+            <Child xs={7} className="breakLongName">
+              <ListItemText
+                primary={showPrimaryText(friend)}
+                secondary={showSecondaryText(friend)}
+              />
+            </Child>
             {/* Button to the right */}
-            <ListItemSecondaryAction>
-              {friend.verified ? <>{manageButton(friend)}</> : role === roles.poster ? <>{cancelButton(friend)}</> : <>{declineButton(friend)} {acceptButton(friend)}</>}
-            </ListItemSecondaryAction>
+            <Child xs={4}>
+              <ListItemSecondaryAction className="noRight">
+                {friend.verified ? <>{manageButton(friend)}</> : role === roles.poster ? <>{cancelButton(friend)}</> : <>{declineButton(friend)} {acceptButton(friend)}</>}
+              </ListItemSecondaryAction>
+            </Child>
           </ListItem>
       );
     })


### PR DESCRIPTION
- Limits display name to 34 characters in both the /registerDetails and /settings pages
- Displays a 'name too long' error if the user enters 35+ characters (spaces count as characters)
- Improved centering of the "Welcome, displayName!" message on the postsView page
- Improved handling of long names (whether they are multiple words or one long megaword) on the account management part of the settings page 

Here are some screen shots of long names in action. Both of these example names are 34 characters long.

<img width="455" alt="Screenshot 2020-05-08 12 38 05" src="https://user-images.githubusercontent.com/5402322/81433342-0367a700-912a-11ea-941c-7c0025e2df24.png">

<img width="472" alt="Screenshot 2020-05-08 12 15 17" src="https://user-images.githubusercontent.com/5402322/81433357-082c5b00-912a-11ea-9a16-8da0a8212b82.png">

<img width="788" alt="Screenshot 2020-05-08 12 08 14" src="https://user-images.githubusercontent.com/5402322/81433407-1f6b4880-912a-11ea-95cb-9efddb51ff90.png">

<img width="507" alt="Screenshot 2020-05-08 12 07 19" src="https://user-images.githubusercontent.com/5402322/81433422-25f9c000-912a-11ea-89a7-3b0af4467d83.png">

<img width="791" alt="Screenshot 2020-05-08 12 07 36" src="https://user-images.githubusercontent.com/5402322/81433436-2a25dd80-912a-11ea-8474-6cd4bbca5e5e.png">
