### PR TITLE
Improvements to account link modals

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,10 @@
   padding-bottom:20px !important;
 }
 
+.padDialog {
+  padding:20px !important;
+}
+
 .credentialsForm {
   width:100%;
 }

--- a/src/shared/features/FamilyMsgView/ModalReply.tsx
+++ b/src/shared/features/FamilyMsgView/ModalReply.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Typography, Container } from '@material-ui/core';
+import { Container } from '@material-ui/core';
 
 import { Reply } from "../../models/reply.model";
 import { replyEmojiArray } from "../../../Icons";

--- a/src/shared/features/HandleReset.tsx
+++ b/src/shared/features/HandleReset.tsx
@@ -14,10 +14,8 @@ import 'firebase/database'; // for additional user properties, like role
 
 import { useHistory, Link } from "react-router-dom";
 import { RouteComponentProps, useLocation } from 'react-router-dom'; // give us 'history' object
-import { Avatar } from "@material-ui/core";
 
 import { verifyActionCode, resetPassword } from 'services/user';
-import Alert from "@material-ui/lab/Alert";
 import BigInput from "shared/components/BigInput/BigInput";
 import CredentialsWrapper from "shared/components/CredentialsWrapper";
 import Child from "shared/components/Child/Child";

--- a/src/shared/features/PostManagement/PostManagement.tsx
+++ b/src/shared/features/PostManagement/PostManagement.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { Container, Card, CardMedia, CardContent, Typography, CardHeader, Avatar, CardActions, IconButton, Button } from '@material-ui/core';
+import { Container, Card, CardMedia, CardContent, Typography, CardHeader, Avatar, CardActions, IconButton } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 
 import { Post } from 'shared/models/post.model';
@@ -66,7 +66,7 @@ const PostManagement: React.FC<IPostManagement> = ({ displayName, posts, onNewRe
   }
 
   const renderPostTitle = (post: Post) => {
-    if (post.receiverIDs.length == 1) {
+    if (post.receiverIDs.length === 1) {
       return <span>You shared this with {post.receiverIDs.length} recipients.</span>
     } else if (post.receiverIDs.length > 1) {
       return <span>You shared this with one recipient.</span>

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -5,7 +5,7 @@ import {roles} from '../../../enums/enums';
 import {getUserSettings} from "services/user";
 import Inbox from '../GrandparentViews/Inbox/Inbox';
 import PostManagement from '../PostManagement/PostManagement';
-import { Link as ButtonLink, Button, Grid } from '@material-ui/core';
+import { Link as ButtonLink, Button } from '@material-ui/core';
 import {getPosts} from 'services/post';
 
 import {Post} from '../../models/post.model';

--- a/src/shared/features/PostsView/components/PendingInvitationModal.tsx
+++ b/src/shared/features/PostsView/components/PendingInvitationModal.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { makeStyles } from '@material-ui/core/styles';
-import { Modal, Button, Grid } from '@material-ui/core';
+import { Button, Container, Dialog, DialogContentText, DialogContent } from '@material-ui/core';
 
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import CancelIcon from '@material-ui/icons/Cancel';
 import { AccountLink } from 'shared/models/accountLink.model';
+import Row from 'shared/components/Row/Row';
+import Child from 'shared/components/Child/Child';
 
 interface IPendingInvitationModal {
   invite: any;
@@ -18,62 +19,55 @@ interface IPendingInvitationModal {
 // todo: pass "Posts" into this functional component
 const PendingInvitationModal: React.FC<IPendingInvitationModal> = ({ invite, isOpen, acceptInvite, declineInvite, onClose }) => {
 
-  const useStyles = makeStyles((theme) => ({
-    paper: {
-        position: 'absolute',
-        width: 500,
-        height: 380,
-        backgroundColor: "white",
-        border: '2px solid gray',
-        boxShadow: theme.shadows[5],
-        padding: theme.spacing(2,4,3),
-        top: '50%',
-        left: '50%',
-        transform: `translate(-50%, -50%)`,
-      },
-    })
-  );
-
-  const classes = useStyles();
-
   return (
-      <Modal
+      <Dialog
         open={isOpen}
         onClose={onClose}
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        <div className={classes.paper}>
-          <Grid container direction="column" spacing={4}>
-            
-            <h2>Accept invite from {invite?.displayName}?</h2>
+        <Container className="padDialog">
+          <Row justify="center" alignItems="center">
+            <Child>
+              <span className="boldText">Accept invitation from {invite?.displayName}?</span>
+            </Child>
+          </Row>
+          <hr/>
 
-            <Grid item xs={12}>
-              <Button 
-                className="colorYes"
-                variant="contained"
-                size="large"
-                fullWidth
-                startIcon={<CheckCircleIcon />}
-                onClick={acceptInvite}>Accept invitation
-              </Button>
-            </Grid>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              <span>Only accept invitations from people you know and recognize.</span>
+            </DialogContentText>
 
-            <Grid item xs={12}>
-              <Button
-                className="colorNo"
-                variant="contained"
-                size="large"
-                fullWidth
-                startIcon={<CancelIcon />}
-                onClick={() => declineInvite(invite)}>No, I don't know this person
-              </Button>
-            </Grid>
+            <Row alignItems="center" justify="space-around">
+              {/* Delete account link */}
 
-          </Grid>
+                {/* Cancel */}
+                <Child xs={12} sm={4}>
+                  <Button 
+                    startIcon={<CancelIcon />}
+                    onClick={() => declineInvite(invite)} 
+                    variant="outlined"
+                    className="buttonDanger">
+                    Decline
+                  </Button>
+                </Child>
 
-        </div>
-      </Modal>
+                <Child xs={12} sm={4}>
+                  <Button
+                    startIcon={<CheckCircleIcon />} 
+                    onClick={acceptInvite} 
+                    variant="contained"
+                    className="buttonSafe"
+                    >
+                    Accept
+                  </Button>
+                </Child>
+            </Row>
+
+          </DialogContent>
+        </Container>
+      </Dialog>
   );
 }
 

--- a/src/shared/features/SettingsView/SettingsView.tsx
+++ b/src/shared/features/SettingsView/SettingsView.tsx
@@ -5,9 +5,7 @@ import { RouteComponentProps } from 'react-router-dom'; // give us 'history' obj
 import { getUserSettings, updateUserSettings, getUserProfile, updateUserProfile } from '../../../services/user';
 
 import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { Box } from '@material-ui/core';
 
 import BigInput from 'shared/components/BigInput/BigInput';
 import LinkedAccountManagement from './components/LinkedAccountManagement';
@@ -18,8 +16,6 @@ import CredentialsWrapper from 'shared/components/CredentialsWrapper';
 import Row from 'shared/components/Row/Row';
 import Column from 'shared/components/Column/Column';
 import Child from 'shared/components/Child/Child';
-import FormSubmitButton from 'shared/components/FormSubmitButton';
-import FormError from 'shared/components/FormError/FormError';
 import CredentialsForm from 'shared/components/CredentialsForm/CredentialsForm';
 
 interface ISettingsView extends RouteComponentProps<any>{

--- a/src/shared/features/SettingsView/components/LinkedAccountManagement.tsx
+++ b/src/shared/features/SettingsView/components/LinkedAccountManagement.tsx
@@ -194,6 +194,7 @@ const LinkedAccountManagement: React.FC<ILinkedAccountManagement> = ({ role }) =
         friend={selectedFriend} 
         unfriendFriend={() => deleteAccountLink(selectedFriend)}
         onClose={handleManageAccountLinkAlertClose} 
+        role={role}
       />
     }
     </>

--- a/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
+++ b/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogContent, DialogContentText, DialogActions, Button, Grid, Typography, Container } from '@material-ui/core';
+import { Dialog, DialogContent, DialogContentText, Button, Container } from '@material-ui/core';
 import { AccountLink } from 'shared/models/accountLink.model';
 import Row from 'shared/components/Row/Row';
 import Child from 'shared/components/Child/Child';

--- a/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
+++ b/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Grid } from '@material-ui/core';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Grid, Typography, Container } from '@material-ui/core';
 import { AccountLink } from 'shared/models/accountLink.model';
+import Row from 'shared/components/Row/Row';
+import Child from 'shared/components/Child/Child';
+import WarningIcon from '@material-ui/icons/Warning';
+import { roles } from 'enums/enums';
 
 interface IManageAccountLinkAlert {
   isOpen: boolean;
   onClose: () => void;
   friend: AccountLink;
   unfriendFriend: (friend: AccountLink) => void;
+  role: String;
 }
 
-const ManageAccountLinkAlert: React.FC<IManageAccountLinkAlert> = ({ isOpen, onClose, friend, unfriendFriend }) => { 
+const ManageAccountLinkAlert: React.FC<IManageAccountLinkAlert> = ({ isOpen, onClose, friend, unfriendFriend, role }) => { 
+
+  const getRemovalString = () => {
+    if (role === roles.poster) {
+      return `You will no longer be able to share updates with ${friend.displayName}.`;
+    } else if (role === roles.receiver) {
+      return `You will no longer receive updates from ${friend.displayName}.`;
+    }
+  }
 
   return (
     <Dialog
@@ -18,31 +31,44 @@ const ManageAccountLinkAlert: React.FC<IManageAccountLinkAlert> = ({ isOpen, onC
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
     >
-    <DialogTitle id="alert-dialog-title">No more updates from {friend.displayName}</DialogTitle>
-    <DialogContent>
-      <DialogContentText id="alert-dialog-description">
-        Warning! You will not get any more updates from {friend.displayName}. Do you want to continue? 
-      </DialogContentText>
-    </DialogContent>
-    <DialogActions>
+      <Container className="padDialog">
+        <Row justify="center" alignItems="center">
+          <Child>
+            <WarningIcon color="error"/>&nbsp;
+          </Child>
 
-      {/* Delete account link */}
-      <Grid container>
-        <Grid item sm={4}>
-        <Button onClick={() => unfriendFriend(friend)} variant="outlined" size="small" className="buttonDanger" autoFocus>
-            Remove them
-          </Button>
-      </Grid>
+          <Child>
+            <span className="boldText">Remove your link with {friend.displayName}</span>
+          </Child>
+        </Row>
+        <hr/>
 
-      {/* Cancel */}
-        <Grid item sm={6}>
-          <Button onClick={onClose} size="small" className="buttonSafe pullRight">
-            Stay connected
-          </Button>
-        </Grid>
-      </Grid>
-      
-    </DialogActions>
+
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+            <span><b>Warning! </b>{getRemovalString()}</span>
+          <br/><br/>
+          <span>Please confirm your choice.</span>
+        </DialogContentText>
+
+        <Row alignItems="center" justify="space-around">
+          {/* Delete account link */}
+          <Child xs={12} sm={4}>
+            <Button onClick={() => unfriendFriend(friend)} variant="outlined" className="buttonDanger">
+              Remove them
+            </Button>
+          </Child>
+
+          {/* Cancel */}
+          <Child xs={12} sm={4}>
+            <Button onClick={onClose} className="buttonSafe">
+              Stay connected
+            </Button>
+          </Child>
+        </Row>
+
+      </DialogContent>
+    </Container>
   </Dialog>
   );
 }

--- a/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
+++ b/src/shared/features/SettingsView/components/ManageAccountLinkAlert.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Grid, Typography, Container } from '@material-ui/core';
+import { Dialog, DialogContent, DialogContentText, DialogActions, Button, Grid, Typography, Container } from '@material-ui/core';
 import { AccountLink } from 'shared/models/accountLink.model';
 import Row from 'shared/components/Row/Row';
 import Child from 'shared/components/Child/Child';

--- a/src/shared/features/SignIn/SignIn.tsx
+++ b/src/shared/features/SignIn/SignIn.tsx
@@ -2,7 +2,6 @@ import React, { useState, useContext } from "react";
 import { AuthContext } from "../../../App";
 import 'firebase/auth';
 
-import { RouteComponentProps } from 'react-router-dom'; // give us 'history' object 
 import { signUserInWithEmailAndPassword, getUserSettings } from "services/user";
 
 import BigInput from "shared/components/BigInput/BigInput";


### PR DESCRIPTION
- Styled and padded the account link modals
- Changed the wording a bit to make the choices clearer (I hope) 
- Added some more cowbell to the unlink modal (! icon, "Warning!" bolded text, etc) 

<img width="660" alt="Screenshot 2020-05-08 13 44 59" src="https://user-images.githubusercontent.com/5402322/81443763-a70d8300-913b-11ea-89a1-1922b771c2f2.png">

<img width="680" alt="Screenshot 2020-05-08 13 44 33" src="https://user-images.githubusercontent.com/5402322/81443815-bd1b4380-913b-11ea-88d3-9d22cf196c47.png">

<img width="495" alt="Screenshot 2020-05-08 14 55 41" src="https://user-images.githubusercontent.com/5402322/81443983-ffdd1b80-913b-11ea-8ba8-da56b93a2b98.png">

 Not well-tested on phone resolutions yet due to header overflow problem. I'll come back to this once the header overflow issues are resolved to see if these modals need any further touchups. 