### PR TITLE
[Inbox page] Changed key to be post.pid instead of post.from

### DIFF
--- a/src/shared/features/GrandparentViews/Inbox/Inbox.tsx
+++ b/src/shared/features/GrandparentViews/Inbox/Inbox.tsx
@@ -77,7 +77,7 @@ const Inbox: React.FC<IInbox> = ({ posts }) => {
 
             <GridList className={classes.gridList} cols={3}>
               {posts.map((post, index: number) => (
-                <GridListTile key={post.from} onClick={() => pressEnvelope(post)} rows={1.25}>
+                <GridListTile key={post.pid} onClick={() => pressEnvelope(post)} rows={1.25}>
                   <img src={post.read ? require("../../../../icons/mail-open.png") : require("../../../../icons/mail-closed.png")}
                        alt={"Letter from " + post.from}
                   />


### PR DESCRIPTION
React goes spam crazy when the key isn't unique, and "post.from" isn't unique (multiple letters can be from the same sender). 

I changed the key to be post.pid, and I think this change is safe, but I'd like it reviewed so that everyone knows about this and so that if this does cause a problem, we know we need a bigger refactor somewhere. 