### PR TITLE
Copyright positioning in Safari fix 

### DIFF
--- a/src/shared/components/Copyright.tsx
+++ b/src/shared/components/Copyright.tsx
@@ -4,7 +4,7 @@ import Child from './Child/Child';
 
 const Copyright: React.FC = () => {
   return (
-    <Child xs={12} container alignContent="flex-end" justify="center">
+    <Child xs={12} container alignContent="flex-end" alignItems="flex-end" justify="center">
       <Box mt={2}>
         <Typography variant="body2" color="textSecondary" align="center">
           {'Copyright © '}


### PR DESCRIPTION
In Safari, align-items was needed to get the Copyright message to appear in a consistent position at the bottom edge of the browser window. ("align-content" was good enough for Chrome but Safari can tell the difference between store brand and name brand CSS)

Verified in Chrome and Safari on Mac (desktop) but not on iPad yet. YOLO.