### PR TITLE
Supported browser text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12579,6 +12579,14 @@
         }
       }
     },
+    "react-device-detect": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.12.1.tgz",
+      "integrity": "sha512-BQ7xIEHx0VqPBGEtEFJRybHnhZ1Qn3BXX8dRR3EKLRfSTKpITUw925VYCGnygZDpmgYSq5NX0IvHGhy0w7Sckg==",
+      "requires": {
+        "ua-parser-js": "^0.7.21"
+      }
+    },
     "react-dictate-button": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-dictate-button/-/react-dictate-button-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.24.0",
     "query-string": "^6.12.1",
     "react": "^16.13.1",
+    "react-device-detect": "^1.12.1",
     "react-dictate-button": "^1.2.2",
     "react-dom": "^16.13.1",
     "react-image-file-resizer": "^0.2.3",

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,11 @@
   display:block;
 }
 
+.fullHeightMobileSafari {
+  height: calc(100vh - 150px);
+  display:block;
+}
+
 .padBottom {
   padding-bottom:20px !important;
 }
@@ -229,27 +234,3 @@ Use: <Box className="devBox">...stuff here...</Box> */
 .wrapReply {
   overflow-wrap:break-word;
 }
-
-/* 
-  const useStyles = makeStyles((theme) => ({
-    paper: {
-      marginTop: theme.spacing(8),
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-    },
-    avatar: {
-      margin: theme.spacing(1),
-      backgroundColor: theme.palette.secondary.main,
-    },
-    form: {
-      width: '100%', // Fix IE 11 issue.
-      marginTop: theme.spacing(1),
-    },
-    submit: {
-      margin: theme.spacing(3, 0, 2),
-    },
-  }));
-
-  const classes = useStyles();
-  */

--- a/src/shared/components/Copyright.tsx
+++ b/src/shared/components/Copyright.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Typography, Link, Box } from '@material-ui/core';
-import Child from './Child/Child';
+import Row from './Row/Row';
 
 const Copyright: React.FC = () => {
   return (
-    <Child xs={12} container alignContent="flex-end" alignItems="flex-end" justify="center">
+    <Row id="copyrightRow" alignContent="flex-end" alignItems="flex-end" justify="center">
       <Box mt={2}>
         <Typography variant="body2" color="textSecondary" align="center">
           {'Copyright © '}
@@ -15,7 +15,7 @@ const Copyright: React.FC = () => {
           {'.'}
         </Typography>
       </Box>
-    </Child>
+    </Row>
   )
 }
 

--- a/src/shared/components/CredentialsWrapper.tsx
+++ b/src/shared/components/CredentialsWrapper.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { GridProps, Box } from '@material-ui/core';
 import Copyright from './Copyright';
 import Row from './Row/Row';
+import { isMobileSafari } from 'react-device-detect';
 
 const CredentialsWrapper: React.FC<GridProps> = ({ children, ...gridProps }) => {
   return (
     <Box pl={6} pr={6}>
-      <Row justify="flex-start" className="fullHeight">
+      <Row justify="flex-start" className={isMobileSafari ? 'fullHeightMobileSafari' : 'fullHeight'}>
           {children}
         <Copyright />
       </Row>


### PR DESCRIPTION
This is a very bare-bones implementation of browser/device compatibility checking. It uses the https://www.npmjs.com/package/react-device-detect package (so you'll have to run npm install if you hop onto this branch to try this out). 

To see it work: 
1. Use an iOS device (iPad/iPhone) 
2. Open the app in a browser that isn't Safari
3. Try to respond a letter using voice or photo
4. You should see a message to the effect of 'iPad and iPhone users must use the Safari browser'

This could definitely be made prettier and it could handle a greater variety of device/browser combos, but for now it's an example of how to disable features/buttons not available to a user because of their device and/or browser. 

Here is a screenshot of it in action (this is on iPad/Chrome, which I confess is my default browser when on my iPad):

![IMG_0246](https://user-images.githubusercontent.com/5402322/82503864-aff93f80-9abf-11ea-848d-4fa5db433c1c.PNG)
