### PR TITLE
UI fixes for final [#1]

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,6 +47,8 @@ body {
   display:flex;
   flex-direction:column;
   width:100%;
+  padding-left:10px;
+  padding-right:10px;
 }
 
 .credentialsForm {

--- a/src/App.css
+++ b/src/App.css
@@ -35,6 +35,10 @@ body {
   display:block;
 }
 
+.marginTop {
+  margin-top:10px !important;
+}
+
 .padBottom {
   padding-bottom:20px !important;
 }

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.css
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.css
@@ -1,6 +1,10 @@
 .photo {
     margin: 10px !important;
+    width:96%;
     max-width: 95%;
+    object-fit:contain;
+    max-height:400px;
+    height:auto;
 }
 .replyCard {
     display: flex;

--- a/src/shared/features/GrandparentViews/Components/GrandparentPostLayout.tsx
+++ b/src/shared/features/GrandparentViews/Components/GrandparentPostLayout.tsx
@@ -20,7 +20,6 @@ const useStyles = makeStyles((theme: Theme) =>
     paper: {
       position: 'absolute',
       maxWidth: 800,
-      padding: theme.spacing(2, 4, 3),
     },
     videoModal: {
       maxHeight: '90vh'
@@ -60,7 +59,7 @@ export const GrandparentPostLayout: React.FC<IPostLayout> = ({from, mediaURL, me
   }
 
   const modalBody = (
-    <div style={modalStyle} className={classes.paper}>
+    <div style={modalStyle} className={`${classes.paper} imagePresentation`}>
 
       {/*Display image or video*/}
       {mediaType === MEDIA_TYPES.IMAGE &&
@@ -75,15 +74,9 @@ export const GrandparentPostLayout: React.FC<IPostLayout> = ({from, mediaURL, me
       {/*Div for closing 'x' overlay*/}
       <div
         onClick={handleClick}
-        style={{
-          position: 'absolute',
-          backgroundColor: '#d8e0e440',
-          color: 'black',
-          top: '0%',
-          right: '0%',
-        }}
+        className="imageXButton"
       >
-        {viewPostIcons.close}
+        <span className="xIcon">{viewPostIcons.close}</span>
       </div>
     </div>
   );

--- a/src/shared/features/GrandparentViews/Grandparent.css
+++ b/src/shared/features/GrandparentViews/Grandparent.css
@@ -1,3 +1,29 @@
+.imagePresentation {
+  background-color:white;
+}
+
+.imagePresentation img {
+  margin:auto auto;
+  border:10px solid white;
+}
+
+.imageXButton {
+  display:block;
+  background-color:#fff;
+  position:absolute;
+  width:56px;
+  height:48px;
+  top:2px;
+  right:2px;
+  color:black;
+  border-radius:10px;
+  text-align:center;
+}
+
+.xIcon {
+  margin:auto auto;
+}
+
 .grandparentReplyText {
   font-size:inherit;
   width:100%;

--- a/src/shared/features/NewFamilyPost/NewFamilyPost.css
+++ b/src/shared/features/NewFamilyPost/NewFamilyPost.css
@@ -2,3 +2,9 @@
     width: 50%;
     margin: auto;
 }
+
+@media screen and (max-width:800px) {
+    .newFamilyPostForm {
+        width: 90%;
+    }
+}

--- a/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
+++ b/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
@@ -259,7 +259,6 @@ const NewFamilyPost: React.FC<IPost> = ({currentPost, closeModal}) => {
             {editing && <Typography component="h2" variant="h5" align="center">
                 Edit Post
             </Typography>}
-            <br/>
             <form className="newFamilyPostForm" noValidate onSubmit={e => submitPost(e)}>
             {(!selectedFile && !photoURL && !videoURL) &&
                 <Row justify="center">
@@ -267,6 +266,7 @@ const NewFamilyPost: React.FC<IPost> = ({currentPost, closeModal}) => {
                         variant="contained"
                         color="secondary"
                         size="small"
+                        className="marginTop"
                         onClick={clickFileUpload}>
                         Select a photo or mp4 video
                     </Button>
@@ -283,11 +283,11 @@ const NewFamilyPost: React.FC<IPost> = ({currentPost, closeModal}) => {
             {selectedFile &&
                 <>
                     {fileType === 'image' &&
-                        <Row justify="center">
+                        <div>
                             <img src={getImageAsUrl()}
                                 className="photo"
                                 alt="Attached img"/>
-                        </Row>
+                        </div>
                     }
                     {fileType === 'video' &&
                         renderVideo


### PR DESCRIPTION
**[View Wrapper padding]**
- Added padding around pages that use ViewWrapper (sign in, join, reset password, register details, settings, etc). This is to fix the items on these pages being directly against the edge of the screen in narrow views. 

(Note it's hard to see the difference in these screens because the background of them is nearly the same color as GitHub's. View the image in its own tab and it's easier to see the padding that was added on left/right.)

Before:
![IMG_2475](https://user-images.githubusercontent.com/5402322/83359899-02015700-a343-11ea-8927-fdd8142affa6.PNG)

After: 
![IMG_CF2C6B61C64E-1](https://user-images.githubusercontent.com/5402322/83359911-0af22880-a343-11ea-83be-c8260dabb1be.jpeg)

**[Family member image upload]**
- Fixed stretching that would occur with a variety of image sizes for image preview
- Page now uses more of the screen's width at narrow resolutions
- Several changes to the way the image preview is displayed to prevent stretching and excessive space that would appear above/below the image on iPhone (Chrome and Safari) and narrow screens in general.

Before (this is what was on Heroku as of 5/31/20):
Desktop Chrome (left), Desktop Safari (right), shown here to illustrate that the issue didn't seem to affect Chrome:
<img width="1618" alt="Screenshot 2020-05-31 13 49 51" src="https://user-images.githubusercontent.com/5402322/83360278-bac89580-a345-11ea-9fd6-0121746c2b5d.png">

Mobile (iPhone), wide image:
![IMG_2498](https://user-images.githubusercontent.com/5402322/83359969-7fc56280-a343-11ea-93ac-1a087fe80386.PNG)

Desktop Safari, square image:
<img width="847" alt="Screenshot 2020-05-31 13 40 33" src="https://user-images.githubusercontent.com/5402322/83360113-65d84f80-a344-11ea-94fb-b0a7be299f38.png">

Desktop Safari, tall image:
<img width="846" alt="Screenshot 2020-05-31 13 40 11" src="https://user-images.githubusercontent.com/5402322/83360118-71c41180-a344-11ea-8f22-c47afcb998b5.png">

Desktop Safari, wide image:
<img width="844" alt="Screenshot 2020-05-31 13 40 22" src="https://user-images.githubusercontent.com/5402322/83360125-7be61000-a344-11ea-8621-05ddc4afeaa3.png">

After:
Mobile (iPhone), wide image:
![IMG_2508](https://user-images.githubusercontent.com/5402322/83359983-9966aa00-a343-11ea-818a-1d073add9d40.PNG)

Desktop Safari, square image:
<img width="846" alt="Screenshot 2020-05-31 13 38 39" src="https://user-images.githubusercontent.com/5402322/83360080-23af0e00-a344-11ea-8499-021be63a4c56.png">

Desktop Safari, tall image:
<img width="852" alt="Screenshot 2020-05-31 13 38 49" src="https://user-images.githubusercontent.com/5402322/83360081-2c9fdf80-a344-11ea-9363-ad2484bdb1a5.png">

Desktop Safari, wide image:
<img width="843" alt="Screenshot 2020-05-31 13 42 38" src="https://user-images.githubusercontent.com/5402322/83360137-9a4c0b80-a344-11ea-91de-d6b97599e4b5.png">

I was not able to test any of this on my Windows computer yet. If anyone has some bandwidht, they should test their own collection of test images on their own devices and look for stretching.

[Grandparent image viewing]
- Adds a white border around enlarged images
- Adds a white background behind the "X" so it's easier to spot on images

Before:
![IMG_0340](https://user-images.githubusercontent.com/5402322/83360205-2f4f0480-a345-11ea-880e-5c96e1c3032c.PNG)

After:
![IMG_0339](https://user-images.githubusercontent.com/5402322/83360204-29592380-a345-11ea-91e4-e07dfc11a9b9.PNG)