### PR TITLE
UI fixes for final [#2]

### DIFF
--- a/src/shared/features/GrandparentViews/Inbox/components/InboxLetter/InboxLetter.css
+++ b/src/shared/features/GrandparentViews/Inbox/components/InboxLetter/InboxLetter.css
@@ -1,7 +1,7 @@
 .envelopeCard {
   margin:18px;
   min-width: 29%;
-  max-width:29%;
+  max-width: 29%;
   height:140px;
   position: relative;
 }
@@ -85,7 +85,7 @@
 }
 
 .letterSenderInfoFront {
-  width:95%;
+  width:100%;
 }
 
 .letterSenderInfoBack {
@@ -142,7 +142,7 @@
 }
 
 .inboxLetterFrom {
-  width:96%;
+  width:100%;
   word-wrap:break-word;
 }
 
@@ -235,8 +235,8 @@
 
 @media screen and (max-width:1000px) {
   .envelopeCard {
-    min-width:40%;
-    max-width: 50%;
+    min-width: 40%;
+    max-width: 40%;
   }
 }
 
@@ -246,7 +246,7 @@
     margin-left:auto;
     margin-right:auto;
     min-width: 60%;
-    max-width: 80%;
+    max-width: 60%;
   }
 
   .inboxLongName {
@@ -258,8 +258,8 @@
   .envelopeCard {
     margin-left:auto;
     margin-right:auto;
-    min-width: 90%;
-    max-width: 96%;
+    min-width: 92%;
+    max-width: 92%;
   }
 }
 


### PR DESCRIPTION
[Grandparent inbox]
- Fix for 'read' envelopes being wider than 'unread' envelopes when the user's name is relatively short and the screen width is near a breakpoint. Right around 520px wide is a good width to notice the problem at, and it helps if the sender's name isn't the max length (32 chars I think? testing with a short name made it easier to see this happening).

Before:
<img width="523" alt="Screenshot 2020-05-31 15 04 14" src="https://user-images.githubusercontent.com/5402322/83361669-6aa30080-a350-11ea-9c82-b98346b32ffb.png">

After:
<img width="531" alt="Screenshot 2020-05-31 15 08 25" src="https://user-images.githubusercontent.com/5402322/83361694-9c1bcc00-a350-11ea-9658-9a5c892597b6.png">

