### PR TITLE
UI fixes for final [#3]

### DIFF
--- a/src/shared/features/FamilyMsgView/FamilyMsgView.css
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.css
@@ -6,6 +6,13 @@
     max-height:400px;
     height:auto;
 }
+
+.postStyle {
+    height: 100%;
+    width: 50%;
+    margin: auto;
+}
+
 .replyCard {
     display: flex;
     flex-direction: column;
@@ -21,4 +28,11 @@
 
 .padLeft {
     padding-left:8px;
+}
+
+@media screen and (max-width:800px) {
+    .postStyle {
+        width: 100%;
+        margin: 6px;
+    }
 }

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.css
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.css
@@ -13,6 +13,12 @@
     margin: auto;
 }
 
+.emojiReply {
+    margin: 5px;
+    height: 7%;
+    width: 7%;
+}
+
 .replyCard {
     display: flex;
     flex-direction: column;
@@ -34,5 +40,11 @@
     .postStyle {
         width: 100%;
         margin: 6px;
+    }
+
+    .emojiReply {
+        margin: 5px;
+        height: 12%;
+        width: 12%;
     }
 }

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -41,11 +41,6 @@ const useStyles = makeStyles((theme: Theme) =>
     paper: {
         minHeight: 300
     },
-    postStyle: {
-      height: "100%",
-      width: '50%',
-      margin: 'auto'
-    },
     spacing: {
         margin: '5px'
     },
@@ -287,7 +282,7 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                 replies.map((reply: Reply, index: number) => {
                     return (
                     <Child xs={12} key={index}>
-                        <div className={classes.postStyle}>
+                        <div className="postStyle">
                             <Card variant="outlined" className="replyCard">
                                 <CardContent className="replyContent">
                                     {isMessage(reply) && 

--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -48,11 +48,6 @@ const useStyles = makeStyles((theme: Theme) =>
         margin: '10px',
         maxWidth: '95%'
     },
-    emojis: {
-        margin: '5px',
-        height: "5%",
-        width: "5%"
-    },
     bottomMargin: {
         marginBottom: '10px'
     }
@@ -270,7 +265,7 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                         <Tooltip title={getTooltip(reply)} key={index} arrow>
                             <img
                                 src={emojiIcons[index]}
-                                className={classes.emojis}
+                                className="emojiReply"
                                 alt="Emoji reply"
                             />
                         </Tooltip>


### PR DESCRIPTION
**[Family member view text replies to post]**
- Replies now use most of the available width when on a narrow screen. This was occurring on all browsers and was particularly noticeable on a mobile device.

Before:
<img width="379" alt="Screenshot 2020-05-31 16 01 06" src="https://user-images.githubusercontent.com/5402322/83362773-6f1fe700-a359-11ea-8b65-262b17e3a641.png">

After:
<img width="383" alt="Screenshot 2020-05-31 16 13 11" src="https://user-images.githubusercontent.com/5402322/83362801-a2fb0c80-a359-11ea-9a81-a22c82802449.png">

At screens 800px or wider, it goes back to using 50% as its width:
<img width="1091" alt="Screenshot 2020-05-31 16 10 47" src="https://user-images.githubusercontent.com/5402322/83362783-85c63e00-a359-11ea-9946-896e8bd21626.png">

**[Family member view emoji replies to post]**
- Emojis now slightly larger on desktop and a lot larger on mobile

Before:
(Screenshot taken before the reply widening work detailed above)
![IMG_2524](https://user-images.githubusercontent.com/5402322/83363282-dcce1200-a35d-11ea-8896-0a244e4404e6.PNG)

After on mobile:
![IMG_2525](https://user-images.githubusercontent.com/5402322/83363279-d50e6d80-a35d-11ea-82dd-e46e9d0aa029.PNG)

After on desktop:
<img width="1116" alt="Screenshot 2020-05-31 16 39 17" src="https://user-images.githubusercontent.com/5402322/83363291-f8391d00-a35d-11ea-81d4-047deea7ae96.png">

