### PR TITLE
UI fixes for final [#4]

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,7 @@
 
 body {
   -webkit-overflow-scrolling: touch;
+  line-height:1.0rem !important;
 }
 
 .marginLRAuto {

--- a/src/shared/features/PostsView/PostsView.css
+++ b/src/shared/features/PostsView/PostsView.css
@@ -2,6 +2,10 @@
   text-align:center;
 }
 
+.noMarginBanner {
+  margin:0 !important;
+}
+
 @media screen and (max-width:830px) {
   .inboxSizer {
     width:100%;

--- a/src/shared/features/PostsView/PostsView.tsx
+++ b/src/shared/features/PostsView/PostsView.tsx
@@ -304,6 +304,14 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
           {/* COLUMN CHILD 2 - CREATE NEW POST and VIEW OLD POSTS */ }
           <Child xs={12} id="inboxChild" className="inboxSizer noMargin">
 
+          <div className="noMargin">
+          {role === roles.receiver && pendingInvitations.length > 0 &&
+                <>
+                  {pendingInviteAlert()}
+                </>
+                }
+                </div>
+
             <Row>
               <Child xs={12}>
 
@@ -344,12 +352,6 @@ const PostsView: React.FC<IPostsView> = ({ setIsLoading, history }) => {
                       </Child>
                   </Row>
                   }
-                </>
-                }
-
-                {role === roles.receiver && pendingInvitations.length > 0 &&
-                <>
-                  {pendingInviteAlert()}
                 </>
                 }
 


### PR DESCRIPTION
A few very minor changes to get the "pending invitations" banner to fit better on iPad and add a tiny space under it.

Before:
![IMG_0345](https://user-images.githubusercontent.com/5402322/83365291-a5b32d00-a36c-11ea-831a-afc4751a3b19.PNG)

After:
![IMG_0346](https://user-images.githubusercontent.com/5402322/83365305-c11e3800-a36c-11ea-875c-8c3b6b5fae70.PNG)

