### PR TITLE
UI fixes for final [#5]

### DIFF
--- a/src/Icons.tsx
+++ b/src/Icons.tsx
@@ -5,7 +5,7 @@ import SendIcon from '@material-ui/icons/Send';
 import DraftsIcon from '@material-ui/icons/Drafts';
 
 import InsertEmoticonIcon from '@material-ui/icons/InsertEmoticon';
-import PermPhoneMsgIcon from '@material-ui/icons/PermPhoneMsg';
+import MicIcon from '@material-ui/icons/Mic';
 import PhotoCameraIcon from '@material-ui/icons/PhotoCamera';
 
 import ZoomInIcon from '@material-ui/icons/ZoomIn';
@@ -40,7 +40,7 @@ export const mailIcons = {
 export const replyOptionIcons = {
   closedEnvelope: <MailIcon />,
   emoji: <InsertEmoticonIcon />,
-  voicemail: <PermPhoneMsgIcon />,
+  voicemail: <MicIcon />,
   photo: <PhotoCameraIcon />
 }
 

--- a/src/shared/features/GrandparentViews/GrandparentReply/GetEmojiReply.tsx
+++ b/src/shared/features/GrandparentViews/GrandparentReply/GetEmojiReply.tsx
@@ -157,7 +157,7 @@ const GetEmojiReply: React.FC = () => {
             buttonActions={[
               () => history.goBack(),
               e => buildReply(e) ] }
-            buttonIcons={[ mailIcons.closedEnvelope, mailIcons.paperAirplane ]}
+            buttonIcons={[ mailIcons.openEnvelope, mailIcons.paperAirplane ]}
             buttonDisabled={[false, (highlightedList.every((element) => element === false))]}
             buttonClasses={['','']}
         />

--- a/src/shared/features/GrandparentViews/GrandparentReply/GetVoiceReply.tsx
+++ b/src/shared/features/GrandparentViews/GrandparentReply/GetVoiceReply.tsx
@@ -254,7 +254,7 @@ const GetVoiceReply: React.FC = () => {
           buttonActions={[
             () => history.goBack(),
             e => buildReply(e) ] }
-          buttonIcons={[ mailIcons.closedEnvelope, mailIcons.paperAirplane ]}
+          buttonIcons={[ mailIcons.openEnvelope, mailIcons.paperAirplane ]}
           buttonDisabled={[false,(replyTooLong || !completeReply.trim())]} />
 
       }


### PR DESCRIPTION
Small icon swaps for consistency between pages:

- Replying with emoji, replying with voice message now use the same "open envelope" icon for "go back" that reply with photo does. (Photo Reply always used the open envelope for the "go back" button, but the other two used a closed envelope. This change makes it so all three pages use the open envelope for "go back".)

<img width="744" alt="Screenshot 2020-05-31 20 00 37" src="https://user-images.githubusercontent.com/5402322/83367292-72c36600-a379-11ea-8b90-e5c4e5865ff3.png">


- The voice message button now uses the same microphone icon that the record button on the voice message page does, replacing the telephone. 

<img width="620" alt="Screenshot 2020-05-31 20 00 32" src="https://user-images.githubusercontent.com/5402322/83367298-78b94700-a379-11ea-8218-8c6bdfc90afd.png">
