### PR TITLE
UI fixes for final [#6]

### DIFF
--- a/src/shared/features/GrandparentViews/Inbox/components/ExtendedInbox/ExtendedInbox.css
+++ b/src/shared/features/GrandparentViews/Inbox/components/ExtendedInbox/ExtendedInbox.css
@@ -2,8 +2,8 @@
   padding-left:40px;
   padding-right:40px;
   height:100%;
-  overflow-y:hidden;
-  overflow:scroll;
+  overflow-y:scroll;
+  overflow-x:hidden;
 }
 
 .extendedInboxModalContent {
@@ -16,7 +16,7 @@
   background-color: white;
   box-shadow: -5px 5px 10px 0px #333, 
   5px 5px 10px 0px #333;
-  overflow-y:scroll;
+  overflow-y:hidden;
 }
 
 .unlockPremium {

--- a/src/shared/features/NewFamilyPost/NewFamilyPost.css
+++ b/src/shared/features/NewFamilyPost/NewFamilyPost.css
@@ -1,6 +1,7 @@
 .newFamilyPostForm {
     width: 50%;
     margin: auto;
+    margin-bottom:50px;
 }
 
 @media screen and (max-width:800px) {

--- a/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
+++ b/src/shared/features/NewFamilyPost/NewFamilyPost.tsx
@@ -375,6 +375,7 @@ const NewFamilyPost: React.FC<IPost> = ({currentPost, closeModal}) => {
                 <Button
                     type="submit"
                     variant="contained"
+                    color="primary"
                     disabled={postTooLong}>
                     Send Post
                 </Button>


### PR DESCRIPTION
**[Extended inbox]**
Windows made it (painfully) obvious that there were overflow:scroll where there shouldn't have been on the extended inbox. This code contains a fix for the excessive scroll bars on Windows Chrome. Tested on Windows/Chrome, MacOS/Safari, iPadOS/Safari

Before:
![scroll-fix-before](https://user-images.githubusercontent.com/5402322/83437382-4b19df80-a405-11ea-9d1b-c7bccd749ad4.PNG)

After:
![scroll-fix-after](https://user-images.githubusercontent.com/5402322/83437380-4b19df80-a405-11ea-9a56-79c7015998dd.PNG)

**[Create post (family member]**
- More margin below the "SEND POST" button so it's not right up against the screen edge on mobile
Before:
![IMG_2556](https://user-images.githubusercontent.com/5402322/83439805-76063280-a409-11ea-8e9f-a95bb7ed4731.PNG)

After:
![IMG_2555](https://user-images.githubusercontent.com/5402322/83439750-62f36280-a409-11ea-87c3-d235dc4fb927.PNG)