### PR TITLE
Shrank the font size of the sent message text

### DIFF
--- a/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
+++ b/src/shared/features/FamilyMsgView/FamilyMsgView.tsx
@@ -206,7 +206,7 @@ const FamilyMsgView: React.FC<IFamilyMsgView> = (props) => {
                             className="photo"
                         />}
                         <br/>
-                        <Typography variant="h5" className={[classes.message, "wrapReply"].join(' ')}>
+                        <Typography variant="body1" className={[classes.message, "wrapReply"].join(' ')}>
                             {post.message}
                         </Typography>
                     </Column>


### PR DESCRIPTION
[Family member post view]

Changed font size from h5 to 'body2' which took it from massive to just a bit large. 

Before:
![IMG_2680](https://user-images.githubusercontent.com/5402322/83471581-aa4e1300-a44a-11ea-96e7-fd2f33d9ac3f.PNG)

After:
![IMG_2681](https://user-images.githubusercontent.com/5402322/83471590-af12c700-a44a-11ea-8c95-c787da25e032.PNG)


Also checked it on desktop Safari and it looks fine there too.
